### PR TITLE
mvn发布包含jar文件

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -44,6 +44,15 @@ task releaseJar(type: Copy, dependsOn: 'build') {
     rename('classes.jar', 'qiniu-android-sdk-' + version + '.jar')
 }
 
+android.libraryVariants.all { variant ->
+    def name = variant.buildType.name
+    def task = project.tasks.create "jar${name.capitalize()}", Jar
+    task.dependsOn variant.javaCompile
+    task.from variant.javaCompile.destinationDir
+    task.exclude '**/R.*',  '**/R$*.*'
+    artifacts.add('archives', task);
+}
+
 setProperty('VERSION_NAME', version)
 setProperty('VERSION_CODE', code)
 


### PR DESCRIPTION
当前mvn发布不包含 jar ，如： qiniu-android-sdk-7.0.4.jar ； 包含  source.jar, javadoc.jar, aar 文件。
<dependency>
    <groupId>com.qiniu</groupId>
    <artifactId>qiniu-android-sdk</artifactId>
    <version>7.0.4</version>
</dependency>

compile 'com.qiniu:qiniu-android-sdk:7.0.4'
compile 'com.qiniu:qiniu-java-sdk:7.0.4@jar'
会优先加载  qiniu-android-sdk-7.0.4.jar ，jar不存在时加载  qiniu-android-sdk-7.0.4.aar 。
jar 存在，且需要加载 aar，按如下方式：
<dependency>
    <groupId>com.qiniu</groupId>
    <artifactId>qiniu-android-sdk</artifactId>
    <version>7.0.4</version>
    <type>aar</aar>
</dependency>

compile 'com.qiniu:qiniu-java-sdk:7.0.4@aar'


看看要不要合并，我们sdk不包含界面元素，只用jar就可以了，没必要使用aar。