### PR TITLE
Update uphost seq

### DIFF
--- a/library/src/androidTest/java/com/qiniu/android/TestFileRecorder.java
+++ b/library/src/androidTest/java/com/qiniu/android/TestFileRecorder.java
@@ -11,7 +11,6 @@ import com.qiniu.android.storage.UpProgressHandler;
 import com.qiniu.android.storage.UploadManager;
 import com.qiniu.android.storage.UploadOptions;
 import com.qiniu.android.storage.persistent.FileRecorder;
-import com.qiniu.android.utils.Etag;
 
 import junit.framework.Assert;
 
@@ -117,7 +116,8 @@ public class TestFileRecorder extends InstrumentationTestCase {
         options = new UploadOptions(null, null, false, new UpProgressHandler() {
             @Override
             public void progress(String key, double percent) {
-                if (percent < pos - config.chunkSize / (size * 1024.0)) {
+                if (size * 1024 > config.putThreshold &&
+                        (percent < pos - config.chunkSize / (size * 1024.0))) {
                     failed = true;
                 }
                 Log.i("qiniutest", "continue progress " + percent);
@@ -126,15 +126,16 @@ public class TestFileRecorder extends InstrumentationTestCase {
 
         runTestOnUiThread(new Runnable() { // THIS IS THE KEY TO SUCCESS
             public void run() {
-                uploadManager.put(tempFile, expectKey, TestConfig.token_z0, new UpCompletionHandler() {
-                    public void complete(String k, ResponseInfo rinfo, JSONObject response) {
-                        Log.i("qiniutest", k + rinfo);
-                        key = k;
-                        info = rinfo;
-                        resp = response;
-                        signal2.countDown();
-                    }
-                }, options);
+                uploadManager.put(tempFile, expectKey, TestConfig.token_z0,
+                        new UpCompletionHandler() {
+                            public void complete(String k, ResponseInfo rinfo, JSONObject response) {
+                                Log.i("qiniutest", k + rinfo);
+                                key = k;
+                                info = rinfo;
+                                resp = response;
+                                signal2.countDown();
+                            }
+                        }, options);
             }
         });
 

--- a/library/src/androidTest/java/com/qiniu/android/common/AutoZoneTest.java
+++ b/library/src/androidTest/java/com/qiniu/android/common/AutoZoneTest.java
@@ -78,7 +78,13 @@ public class AutoZoneTest extends AndroidTestCase {
         }
         ZoneInfo info = autoZone.zoneInfo(ak, bkt);
 //        Log.d("zone0: ", info.toString());
-
+        Assert.assertNotNull(info);
+        String d = info.upDomainsList.get(1);
+        if(d.contains("-")) {
+            Assert.assertTrue("shoud be origin up host: " + d, d.length() < 20);
+        } else {
+            Assert.assertTrue("shoud be origin up host: " + d, d.length() < 15);
+        }
         ZoneInfo info2 = autoZone.zoneInfo(ak, bkt);
         Assert.assertSame(info, info2);
 

--- a/library/src/androidTest/java/com/qiniu/android/common/AutoZoneTest.java
+++ b/library/src/androidTest/java/com/qiniu/android/common/AutoZoneTest.java
@@ -81,9 +81,13 @@ public class AutoZoneTest extends AndroidTestCase {
         Assert.assertNotNull(info);
         String d = info.upDomainsList.get(1);
         if(d.contains("-")) {
-            Assert.assertTrue("shoud be origin up host: " + d, d.length() < 20);
+            // up-na0.qiniup.com up-z0.qiniup.com up-z1.qiniup.com
+            Assert.assertTrue("shoud be origin up host: " + d,
+                    d.length() < "up-na0.qiniup.com".length() + 1);
         } else {
-            Assert.assertTrue("shoud be origin up host: " + d, d.length() < 15);
+            // up.qiniup.com
+            Assert.assertTrue("shoud be origin up host: " + d,
+                    d.length() < "up.qiniup.com".length() + 1);
         }
         ZoneInfo info2 = autoZone.zoneInfo(ak, bkt);
         Assert.assertSame(info, info2);

--- a/library/src/main/java/com/qiniu/android/common/FixedZone.java
+++ b/library/src/main/java/com/qiniu/android/common/FixedZone.java
@@ -17,9 +17,9 @@ public final class FixedZone extends Zone {
      * 华东机房
      */
     public static final Zone zone0 = new FixedZone(new String[]{
-            "upload.qiniup.com", "upload-nb.qiniup.com",
-            "upload-xs.qiniup.com", "up.qiniup.com",
-            "up-nb.qiniup.com", "up-xs.qiniup.com",
+            "upload.qiniup.com", "up.qiniup.com",
+            "upload-nb.qiniup.com", "up-xs.qiniup.com",
+            "upload-xs.qiniup.com", "up-nb.qiniup.com",
             "upload.qbox.me", "up.qbox.me"
     });
 
@@ -35,9 +35,9 @@ public final class FixedZone extends Zone {
      * 华南机房
      */
     public static final Zone zone2 = new FixedZone(new String[]{
-            "upload-z2.qiniup.com", "upload-gz.qiniup.com",
-            "upload-fs.qiniup.com", "up-z2.qiniup.com",
-            "up-gz.qiniup.com", "up-fs.qiniup.com",
+            "upload-z2.qiniup.com", "up-z2.qiniup.com",
+            "upload-gz.qiniup.com", "up-gz.qiniup.com",
+            "upload-fs.qiniup.com", "up-fs.qiniup.com",
             "upload-z2.qbox.me", "up-z2.qbox.me"
     });
 


### PR DESCRIPTION
1. 顺序要改为： acc.main, src.main,old_acc.main, old_src.main, acc.backup, src.backup ;
2. 若一个失败，标记 10 分钟内不使用，且将次域名移动到队列尾部；

acc.main, acc.backup 其解析出的 ip 大部分是重复的，acc.main  若这个失败，重试时使用 acc.backup 这个失败的可能性    应该   比    src.main  这个要大。