### PR TITLE
如果回调接口返回的是void类型，则这里是null字符串

### DIFF
--- a/library/src/main/java/com/qiniu/android/http/Client.java
+++ b/library/src/main/java/com/qiniu/android/http/Client.java
@@ -121,7 +121,7 @@ public final class Client {
     private static JSONObject buildJsonResp(byte[] body) throws Exception {
         String str = new String(body, Constants.UTF_8);
         // 允许 空 字符串
-        if (StringUtils.isNullOrEmpty(str)) {
+        if (StringUtils.isNullOrEmpty(str) || "null".equals(str)) {
             return new JSONObject();
         }
         return new JSONObject(str);


### PR DESCRIPTION
如果回调接口返回的是void类型，则这里是"null"字符串，然后会导致解析json失败，从而导致sdk的返回的对象`ResponseInfo`里面的`isOk()`方法返回false，但是实际上，上传图片是成功的。